### PR TITLE
更新了箱子被破坏时的逻辑

### DIFF
--- a/src/main/java/io/ncbpfluffybear/fluffymachines/items/Barrel.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/items/Barrel.java
@@ -80,6 +80,8 @@ public class Barrel extends NonHopperableBlock implements DoubleHologramOwner {
 
     protected final ItemSetting<Integer> barrelCapacity;
 
+    private boolean isTriedToRemoveIt = false;
+
     public Barrel(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe,
                   int MAX_STORAGE) {
         super(category, item, recipeType, recipe);
@@ -159,9 +161,21 @@ public class Barrel extends NonHopperableBlock implements DoubleHologramOwner {
                     }
 
                     if (itemCount > 5) {
-                        Utils.send(p, "&在打破它之前,最好先把里面的东西拿走!");
+                        if(isTriedToRemoveIt) { 
+                            isTriedToRemoveIt = false;
+                            setStored(b, 0);
+                            updateMenu(b, inv, true, capacity);
+                            removeHologram(b);
+                            return;
+                        }
+
+                        Utils.send(p, "&c在打破它之前, 最好先把附近的东西拿走! 若确定要直接打破它, 请再次打破它! 注意! 这将丢失存储的所有物品!");
+                        isTriedToRemoveIt = true;
                         e.setCancelled(true);
                         return;
+                    }
+                    else {
+                        isTriedToRemoveIt = false;
                     }
 
                     inv.dropItems(b.getLocation(), INPUT_SLOTS);


### PR DESCRIPTION
当玩家想要破坏一个存储大量物品的蓬松箱子时，第一次会掉落3240个物品，之后会因为附近有太多物品而禁止玩家破坏箱子

新增的逻辑是：
当周围物品过多时若玩家尝试破坏箱子，首次会提示周围物品过多，建议先移动物品；并提示玩家若执意破坏箱子，请再次破坏，但是将丢失所有存储的物品